### PR TITLE
no need for /cvmfs/cms.cern.ch/crab3/crab.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ Old, but working instructions are below, but if you want to quickly publish file
 then do this:
 1. Check out this repository
 2. `cmsrel CMSSW_7_4_1_patch1; cd CMSSW_7_4_1_patch1/src`
-3. `cmsenv; source /cvmfs/cms.cern.ch/crab3/crab.sh`
-4. `source  /cvmfs/cms.cern.ch/common/crab-setup.sh`
-5. Inside of the `v2` folder, edit `config.py` and `InsertFiles.py` with the appropriate parameters (denoted by "change this" or similar)
-6. Do `python InsertFiles.py`
-7. Check that the dataset was published properly by pasting the name into DAS.
+3. `cmsenv; source /cvmfs/cms.cern.ch/common/crab-setup.sh`
+4. Inside of the `v2` folder, edit `config.py` and `InsertFiles.py` with the appropriate parameters (denoted by "change this" or similar)
+5. Do `python InsertFiles.py`
+6. Check that the dataset was published properly by pasting the name into DAS.
 
 
 ##### ATTENTION! 


### PR DESCRIPTION
currently /cvmfs/cms.cern.ch/crab3/crab.sh is only a symbolic link to /cvmfs/cms.cern.ch/crab3/crab.sh anyhow !